### PR TITLE
Bump wildfly-common to 1.2.0

### DIFF
--- a/charts/eap74/Chart.yaml
+++ b/charts/eap74/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: eap74
 description: Build and Deploy EAP 7.4 applications on OpenShift
 type: application
-version: 1.0.0
+version: 1.1.0
 
 appVersion: "7.4.0.Beta"
 
 dependencies:
 - name: wildfly-common
-  version: 1.1.0
+  version: 1.2.0
   repository: https://docs.wildfly.org/wildfly-charts/
   # for local development
   #repository: file://../../../wildfly-charts/charts/wildfly-common

--- a/charts/eap74/README.md
+++ b/charts/eap74/README.md
@@ -76,7 +76,7 @@ The configuration to build the application image is configured in a `build` sect
 | `build.s2i.jdk8.runtimeImage` | EAP S2I Runtime image for JDK 8 | `registry.redhat.io/jboss-eap-7-tech-preview/eap74-openjdk8-runtime-openshift-rhel7` | [EAP Documentation](https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.3/html/getting_started_with_jboss_eap_for_openshift_container_platform/index)  |
 | `build.s2i.jdk11.builderImage` | EAP S2I Builder image for JDK 11 | `registry.redhat.io/jboss-eap-7-tech-preview/eap74-openjdk11-openshift-rhel8` | [EAP Documentation](https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.3/html/getting_started_with_jboss_eap_for_openshift_container_platform/index)  |
 | `build.s2i.jdk11.runtimeImage` | EAP S2I Runtime image for JDK 11 | `registry.redhat.io/jboss-eap-7-tech-preview/eap74-openjdk11-runtime-openshift-rhel8` | [EAP Documentation](https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.3/html/getting_started_with_jboss_eap_for_openshift_container_platform/index)  |
-| `build.s2i.galleonLayers` | A comma separated list of layer names to compose a EAP server | - |  [EAP Documentation](https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.3/html/getting_started_with_jboss_eap_for_openshift_container_platform/index) |
+| `build.s2i.galleonLayers` | A list of layer names to compose a EAP server | - |  [EAP Documentation](https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.3/html/getting_started_with_jboss_eap_for_openshift_container_platform/index) |
 
 
 

--- a/charts/eap74/values.schema.json
+++ b/charts/eap74/values.schema.json
@@ -258,9 +258,11 @@
                           }
                         },
                         "galleonLayers": {
-                            "description": "List of Galleon Layers to provisions (separated by commas)",
-                            "type": ["string", "null"]
-                        }
+                          "description": "List of Galleon Layers to provision",
+                          "type": ["string", "array", "null"],
+                          "items": {
+                            "type": "string"
+                          }
                     }
                 }
             }

--- a/examples/eap74/helloworld-rs/helloworld-rs-app.yaml
+++ b/examples/eap74/helloworld-rs/helloworld-rs-app.yaml
@@ -4,7 +4,8 @@ build:
   pullSecret: eap-pull-secret
   s2i:
     jdk: "11"
-    galleonLayers: 'jaxrs-server'
+    galleonLayers:
+      - jaxrs-server
   env:
   - name: ARTIFACT_DIR
     value: helloworld-rs/target


### PR DESCRIPTION
build.s2i.galleonLayers can now either be a CSV string or an array of
strings.

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>