### PR TITLE
[#5] Add build.s2i.arch to support other architecture

### DIFF
--- a/charts/eap74/templates/_helpers.tpl
+++ b/charts/eap74/templates/_helpers.tpl
@@ -2,12 +2,16 @@
 {{/*
 eap74.eapBuilderImage corresponds to the imagestream for the EAP S2I Builder image.
 It depends on the build.s2i.jdkVersion.
+
+TODO: the build.s2i.arch is not used and is hard-coded to "amd64".
+When we add support for Z-Series and PowerPC, we will rely on the value of build.s2i.arch
+to get the proper S2I images (and validate that only jdk11 can be used with Z & P)
 */}}
 {{- define "eap74.eapBuilderImage" -}}
 {{- if eq .Values.build.s2i.jdk "8"  -}}
-{{ .Values.build.s2i.jdk8.builderImage}}:{{ include "eap74.version" . }}
+{{ .Values.build.s2i.amd64.jdk8.builderImage}}:{{ include "eap74.version" . }}
 {{- else -}}
-{{ .Values.build.s2i.jdk11.builderImage}}:{{ include "eap74.version" . }}
+{{ .Values.build.s2i.amd64.jdk11.builderImage}}:{{ include "eap74.version" . }}
 {{- end -}}
 {{- end -}}
 
@@ -17,9 +21,9 @@ It depends on the build.s2i.jdkVersion.
 */}}
 {{- define "eap74.eapRuntimeImage" -}}
 {{- if eq .Values.build.s2i.jdk "8"  -}}
-{{ .Values.build.s2i.jdk8.runtimeImage}}:{{ include "eap74.version" . }}
+{{ .Values.build.s2i.amd64.jdk8.runtimeImage}}:{{ include "eap74.version" . }}
 {{- else -}}
-{{ .Values.build.s2i.jdk11.runtimeImage}}:{{ include "eap74.version" . }}
+{{ .Values.build.s2i.amd64.jdk11.runtimeImage}}:{{ include "eap74.version" . }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/eap74/values.schema.json
+++ b/charts/eap74/values.schema.json
@@ -225,36 +225,48 @@
                             "description": "EAP 7 version. If not specified, the Helm's appVersion will be used instead.",
                             "type": ["string", "null"]
                         },
+                        "arch": {
+                          "description": "Architecture of the EAP S2I images",
+                          "type": "string",
+                          "enum": ["amd64"],
+                          "default": "amd64"
+                        },
                         "jdk": {
                           "description": "JDK Version of the EAP S2I images",
                           "type": "string",
                           "enum": ["8", "11"],
                           "default": "11"
                         },
-                        "jdk8": {
+                        "amd64": {
+                          "description": "EAP S2I images for amd64 architecture",
                           "type": "object",
                           "properties": {
-                            "builderImage": {
-                              "description": "EAP S2I Builder image for JDK 8",
-                              "type": "string"
+                            "jdk8": {
+                              "type": "object",
+                              "properties": {
+                                "builderImage": {
+                                  "description": "EAP S2I Builder image for JDK 8",
+                                  "type": "string"
+                                },
+                                "runtimeImage": {
+                                  "description": "EAP S2I Runtime image for JDK 8",
+                                  "type": "string"
+                                }
+                              }
                             },
-                            "runtimeImage": {
-                              "description": "EAP S2I Runtime image for JDK 8",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "jdk11": {
-                          "type": "object",
-                          "properties": {
-                            "builderImage": {
-                              "description": "EAP S2I Builder image for JDK 11",
-                              "type": "string"
-                            },
-                            "runtimeImage": {
-                              "description": "EAP S2I Runtime image for JDK 11",
-                              "type": "string"
-                            }
+                            "jdk11": {
+                              "type": "object",
+                              "properties": {
+                                "builderImage": {
+                                  "description": "EAP S2I Builder image for JDK 11",
+                                  "type": "string"
+                                },
+                                "runtimeImage": {
+                                  "description": "EAP S2I Runtime image for JDK 11",
+                                  "type": "string"
+                                }
+                              }
+                            }    
                           }
                         },
                         "galleonLayers": {

--- a/charts/eap74/values.yaml
+++ b/charts/eap74/values.yaml
@@ -10,12 +10,14 @@ build:
   s2i:
     version: latest
     jdk: "11"
-    jdk8:
-      builderImage: registry.redhat.io/jboss-eap-7-tech-preview/eap74-openjdk8-openshift-rhel7
-      runtimeImage: registry.redhat.io/jboss-eap-7-tech-preview/eap74-openjdk8-runtime-openshift-rhel7
-    jdk11:
-      builderImage: registry.redhat.io/jboss-eap-7-tech-preview/eap74-openjdk11-openshift-rhel8
-      runtimeImage: registry.redhat.io/jboss-eap-7-tech-preview/eap74-openjdk11-runtime-openshift-rhel8
+    arch: "amd64"
+    amd64:
+      jdk8:
+        builderImage: registry.redhat.io/jboss-eap-7-tech-preview/eap74-openjdk8-openshift-rhel7
+        runtimeImage: registry.redhat.io/jboss-eap-7-tech-preview/eap74-openjdk8-runtime-openshift-rhel7
+      jdk11:
+        builderImage: registry.redhat.io/jboss-eap-7-tech-preview/eap74-openjdk11-openshift-rhel8
+        runtimeImage: registry.redhat.io/jboss-eap-7-tech-preview/eap74-openjdk11-runtime-openshift-rhel8
   output:
     kind: "ImageStreamTag"
   triggers: {}


### PR DESCRIPTION
The only available architecture is "amd64".
Support for ppc64le, s390x will be added when the corresponding EAP S2I
images are released.

This fixes #5.