### PR TITLE
[#5] Add build.s2i.arch to support other architecture

### DIFF
--- a/charts/eap74/values.schema.json
+++ b/charts/eap74/values.schema.json
@@ -275,6 +275,7 @@
                           "items": {
                             "type": "string"
                           }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fix invalid format for values.schema.json

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>