### PR TITLE
Bump wildlfy-common to 1.3.1

### DIFF
--- a/charts/eap74/Chart.yaml
+++ b/charts/eap74/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: eap74
 description: Build and Deploy EAP 7.4 applications on OpenShift
 type: application
-version: 1.1.0
+version: 1.1.1
 
 appVersion: "7.4"
 
 dependencies:
 - name: wildfly-common
-  version: 1.3.0
+  version: 1.3.1
   repository: https://docs.wildfly.org/wildfly-charts/
   # for local development
   #repository: file://../../../wildfly-charts/charts/wildfly-common


### PR DESCRIPTION
Bump eap74 version to 1.1.1

wildlfy-common 1.3.1 incorporates a fix for JBEAP-22614

JIRA: https://issues.redhat.com/browse/JBEAP-22614

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>