### PR TITLE
Bump wildlfy-common to 1.3.1

### DIFF
--- a/charts/eap-xp3/Chart.yaml
+++ b/charts/eap-xp3/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: eap-xp3
 description: Build and Deploy EAP XP3 applications on OpenShift
 type: application
-version: 1.0.0
+version: 1.0.1
 
 appVersion: "3.0"
 
 dependencies:
 - name: wildfly-common
-  version: 1.3.0
+  version: 1.3.1
   repository: https://docs.wildfly.org/wildfly-charts/
   # for local development
   #repository: file://../../../wildfly-charts/charts/wildfly-common


### PR DESCRIPTION
Bump eap-xp3 version to 1.0.1

wildlfy-common 1.3.1 incorporates a fix for JBEAP-22615

JIRA: https://issues.redhat.com/browse/JBEAP-22615

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>