### PR TITLE
Fixing description string that contains special chars which make Javadoc generators fail with errors

### DIFF
--- a/charts/eap74/values.schema.json
+++ b/charts/eap74/values.schema.json
@@ -277,7 +277,7 @@
                           }
                         },
                         "featurePacks": {
-                          "description": "List of additional Galleon feature-packs identified by Maven coordinates (`<groupId>:<artifactId>:<version>`)",
+                          "description": "List of additional Galleon feature-packs identified by Maven coordinates (`&lt;groupId&gt;:&lt;artifactId&gt;:&lt;version&gt;`)",
                           "type": ["string", "array", "null"],
                           "items": {
                             "type": "string"


### PR DESCRIPTION
We have troubles when generating the Java model and related Javadoc because of some special chars (i.e.e `>`, `<`) in some fields `description` property.