### PR TITLE
[JBEAP-24436] Update metering labels

### DIFF
--- a/charts/eap8/templates/_helpers.tpl
+++ b/charts/eap8/templates/_helpers.tpl
@@ -39,11 +39,11 @@ app.openshift.io/runtime: eap
 
 {{- define "eap8.metering.labels" -}}
 com.company: "Red_Hat"
-com.redhat.product-name: "Red_Hat_Runtimes"
-com.redhat.product-version: "2023-Q1"
-com.redhat.component-name: EAP
-com.redhat.component-version: "8.0"
-com.redhat.component-type: application
+rht.prod_name: "Red_Hat_Runtimes"
+rht.prod_ver: "2023-Q1"
+rht.comp: "EAP"
+rht.comp_ver: "8.0"
+rht.subcomp_t: "application"
 {{- end }}
 
 {{- define "eap8.metadata.labels" -}}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-24436 

Update metering labels as per https://spaces.redhat.com/pages/viewpage.action?spaceKey=RHMWRT&title=Metering+Runtimes+in+OpenShift

I also wonder if we need to backport this change to `main` branch for `EAP 7.4` (`XP 4` contains correct labels, `XP 3` is EOL).