### PR TITLE
[JBEAP-24445] Update metering labels

### DIFF
--- a/charts/eap74/templates/_helpers.tpl
+++ b/charts/eap74/templates/_helpers.tpl
@@ -52,11 +52,11 @@ app.openshift.io/runtime: eap
 
 {{- define "eap74.metering.labels" -}}
 com.company: "Red_Hat"
-com.redhat.product-name: "Red_Hat_Runtimes"
-com.redhat.product-version: "2021-Q2"
-com.redhat.component-name: EAP
-com.redhat.component-version: {{ quote .Chart.AppVersion }}
-com.redhat.component-type: application
+rht.prod_name: "Red_Hat_Runtimes"
+rht.prod_ver: "2021-Q2"
+rht.comp: "EAP"
+rht.comp_ver: {{ quote .Chart.AppVersion }}
+rht.subcomp_t: "application"
 {{- end }}
 
 {{- define "eap74.metadata.labels" -}}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-24445

Update metering labels as per https://spaces.redhat.com/pages/viewpage.action?spaceKey=RHMWRT&title=Metering+Runtimes+in+OpenShift

eap8-dev PR https://github.com/jbossas/eap-charts/pull/37