### PR TITLE
Update widlfy-common to 2.1.1

### DIFF
--- a/charts/eap8/Chart.yaml
+++ b/charts/eap8/Chart.yaml
@@ -19,7 +19,7 @@ annotations:
 
 dependencies:
 - name: wildfly-common
-  version: 2.1.0
+  version: 2.1.1
   repository: https://docs.wildfly.org/wildfly-charts/
   # for local development
   #repository: file://../../../wildfly-charts/charts/wildfly-common


### PR DESCRIPTION
Release Notes:
https://github.com/wildfly/wildfly-charts/releases/tag/wildfly-common-2.1.1

This incorporates the following changes:

[109] Update app.kubernetes.io/name label
[106] Add annotation to link the deployment to its source code