### PR TITLE
correct invalid main branch link

### DIFF
--- a/index.md
+++ b/index.md
@@ -20,7 +20,7 @@ jboss-eap/eap74         1.0.0           7.4             A Helm chart to build an
 
 # Install a Helm Release
 
-We can build and deploy the [helloworld-rs quickstart](https://github.com/jboss-developer/jboss-eap-quickstarts/tree/7.4.x/helloworld-rs) with this [example file](https://raw.githubusercontent.com/jbossas/eap-charts/main/examples/eap7/helloworld-rs/helloworld-rs-app.yaml):
+We can build and deploy the [helloworld-rs quickstart](https://github.com/jboss-developer/jboss-eap-quickstarts/tree/7.4.x/helloworld-rs) with this [example file](https://raw.githubusercontent.com/jbossas/eap-charts/eap74/examples/eap74/helloworld-rs/helloworld-rs-app.yaml):
 
 ```
 $ helm install helloworld-rs-app \


### PR DESCRIPTION
chart and examples for the eap74 had been removed from the main branch as part of https://github.com/jbossas/eap-charts/issues/28