### PR TITLE
[JBEAP-28618] Fix startup probe

### DIFF
--- a/charts/eap-xp6/values.yaml
+++ b/charts/eap-xp6/values.yaml
@@ -33,7 +33,6 @@ deploy:
     httpGet:
       path: /health/live
       port: admin
-    initialDelaySeconds: 60
   readinessProbe:
     httpGet:
       path: /health/ready
@@ -41,6 +40,7 @@ deploy:
     initialDelaySeconds: 10
   startupProbe:
     httpGet:
-      path: /health/live
+      path: /health/started
       port: admin
-    initialDelaySeconds: 60
+    initialDelaySeconds: 10
+    failureThreshold: 11


### PR DESCRIPTION
to point to /health/started

this fixes https://issues.redhat.com/browse/JBEAP-28618