### PR TITLE
[JBEAP-28619] Fix startup probe

### DIFF
--- a/charts/eap81/values.yaml
+++ b/charts/eap81/values.yaml
@@ -32,7 +32,6 @@ deploy:
     httpGet:
       path: /health/live
       port: admin
-    initialDelaySeconds: 60
   readinessProbe:
     httpGet:
       path: /health/ready
@@ -40,6 +39,7 @@ deploy:
     initialDelaySeconds: 10
   startupProbe:
     httpGet:
-      path: /health/live
+      path: /health/started
       port: admin
-    initialDelaySeconds: 60
+    initialDelaySeconds: 10
+    failureThreshold: 11


### PR DESCRIPTION
to point to /health/started

this fixes https://issues.redhat.com/browse/JBEAP-28619