### PR TITLE
Use images for EAP 8.1 GA

### DIFF
--- a/charts/eap81/values.yaml
+++ b/charts/eap81/values.yaml
@@ -13,11 +13,11 @@ build:
     kind: DockerImage
     jdk: "17"
     jdk17:
-      builderImage: registry.redhat.io/jboss-eap-8-tech-preview/eap81-openjdk17-builder-openshift-rhel9:latest
-      runtimeImage: registry.redhat.io/jboss-eap-8-tech-preview/eap81-openjdk17-runtime-openshift-rhel9:latest
+      builderImage: registry.redhat.io/jboss-eap-8/eap81-openjdk17-builder-openshift-rhel9:latest
+      runtimeImage: registry.redhat.io/jboss-eap-8/eap81-openjdk17-runtime-openshift-rhel9:latest
     jdk21:
-      builderImage: registry.redhat.io/jboss-eap-8-tech-preview/eap81-openjdk21-builder-openshift-rhel9:latest
-      runtimeImage: registry.redhat.io/jboss-eap-8-tech-preview/eap81-openjdk21-runtime-openshift-rhel9:latest
+      builderImage: registry.redhat.io/jboss-eap-8/eap81-openjdk21-builder-openshift-rhel9:latest
+      runtimeImage: registry.redhat.io/jboss-eap-8/eap81-openjdk21-runtime-openshift-rhel9:latest
   output:
     kind: "ImageStreamTag"
   triggers: {}


### PR DESCRIPTION
When EAP 8.1 GA is released, its images will be in the jboss-eap-8 namespace (while EAP 8.1 Beta images were in the jboss-eap-8-tech-preview namespace).